### PR TITLE
authenticode: Exclude testdata from published package

### DIFF
--- a/authenticode/Cargo.toml
+++ b/authenticode/Cargo.toml
@@ -11,6 +11,7 @@ name = "authenticode"
 categories = ["data-structures", "embedded", "no-std"]
 description = "Library for working with Authenticode (no-std)"
 keywords = ["authenticode", "no_std"]
+exclude = ["tests/testdata"]
 
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
The testdata directory contains test executables and keys, either of which might be "disliked" by tools that download crates. Since nothing ordinarily runs tests on published packages (tests are run directly on the repo), there's no value to including these files.