### PR TITLE
provide access to encapsulated content in support of message digest verification

### DIFF
--- a/authenticode/src/signature.rs
+++ b/authenticode/src/signature.rs
@@ -251,6 +251,15 @@ impl AuthenticodeSignature {
         self.signer_info().signature.as_bytes()
     }
 
+    /// Get the encapsulated content.
+    pub fn encapsulated_content(&self) -> Option<&[u8]> {
+        self.signed_data
+            .encap_content_info
+            .econtent
+            .as_ref()
+            .map(|c| c.value())
+    }
+
     /// Get the certificate chain.
     pub fn certificates(&self) -> impl Iterator<Item = &Certificate> {
         self.signed_data


### PR DESCRIPTION
Example usage of this change is here: https://github.com/carl-wallace/tpm_cab_verify/blob/main/src/signer.rs#L37