### PR TITLE
Update to object 0.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]

--- a/authenticode-tool/Cargo.toml
+++ b/authenticode-tool/Cargo.toml
@@ -27,6 +27,6 @@ clap = { version = "4.4.7", features = ["derive"] }
 cms = { version = "0.2.0", default-features = false }
 der = { version = "0.7.0", default-features = false, features = ["std"] }
 digest = { version = "0.10.0", default-features = false }
-object = { version = "0.35.0", default-features = false, features = ["pe", "read_core", "std"] }
+object = { version = "0.36.0", default-features = false, features = ["pe", "read_core", "std"] }
 sha1 = { version = "0.10.0", default-features = false }
 sha2 = { version = "0.10.0", default-features = false }

--- a/authenticode/Cargo.toml
+++ b/authenticode/Cargo.toml
@@ -28,7 +28,7 @@ cms = { version = "0.2.0", default-features = false }
 const-oid = { version = "0.9.0", default-features = false }
 der = { version = "0.7.0", default-features = false, features = ["derive"] }
 digest = { version = "0.10.0", default-features = false }
-object = { version = "0.35.0", default-features = false, features = ["pe", "read_core", "unaligned"], optional = true }
+object = { version = "0.36.0", default-features = false, features = ["pe", "read_core", "unaligned"], optional = true }
 rsa = { version = "0.9.0", default-features = false }
 sha1 = { version = "0.10.0", default-features = false, features = ["oid"] }
 sha2 = { version = "0.10.0", default-features = false, features = ["oid"] }

--- a/authenticode/src/pe_object.rs
+++ b/authenticode/src/pe_object.rs
@@ -13,7 +13,7 @@ use core::ops::Range;
 use object::pe::{ImageDataDirectory, IMAGE_DIRECTORY_ENTRY_SECURITY};
 use object::read::pe::ImageOptionalHeader;
 use object::read::pe::{ImageNtHeaders, PeFile};
-use object::{pod, LittleEndian};
+use object::{pod, LittleEndian, SectionIndex};
 
 impl<'data, I> PeTrait for PeFile<'data, I>
 where
@@ -31,8 +31,10 @@ where
         &self,
         index: usize,
     ) -> Result<Range<usize>, PeOffsetError> {
-        let section =
-            self.section_table().section(index).expect("invalid index");
+        let section = self
+            .section_table()
+            .section(SectionIndex(index))
+            .expect("invalid index");
         let start =
             usize_from_u32(section.pointer_to_raw_data.get(LittleEndian));
         let size = usize_from_u32(section.size_of_raw_data.get(LittleEndian));


### PR DESCRIPTION
Minor fix required: section lookup now takes a `SectionIndex` as input, which is a newtype around `usize`.