### PR TITLE
Switch cargo-deny job to use the docker action

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -17,7 +17,6 @@ allow = [
 [bans]
 multiple-versions = "deny"
 skip = [
-     { name = "bitflags", version = "1.3.2" },
      { name = "rsa", version = "0.9.4" },
 ]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,16 +82,11 @@ jobs:
 
   cargo-deny:
     runs-on: ubuntu-latest
-    env:
-      cdver: 0.14.20
     steps:
     - uses: actions/checkout@v4
-    # Download a pinned version of cargo-deny to make this CI job faster.
-    - run: |
-        curl --fail --location --output cargo-deny.tar.gz https://github.com/EmbarkStudios/cargo-deny/releases/download/$cdver/cargo-deny-$cdver-x86_64-unknown-linux-musl.tar.gz
-        echo "1c9f8cfc23647346f1aa7ba0ed3167191f3198aba3dc5a957fda6f85a82fc424 cargo-deny.tar.gz" | sha256sum --check
-        tar xvf cargo-deny.tar.gz
-        cargo-deny-$cdver-x86_64-unknown-linux-musl/cargo-deny deny check
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        arguments: --workspace --all-features
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This makes it easier to stay on the latest version of cargo-deny.

Also remove a no-longer-needed entry from the cargo-deny config.