### PR TITLE
Add workspace dep for clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/google/authenticode-rs"
 rust-version = "1.74"
 version = "0.4.3"
+
+[workspace.dependencies]
+clap = { version = "4.4.7", features = ["derive"] }

--- a/authenticode-tool/Cargo.toml
+++ b/authenticode-tool/Cargo.toml
@@ -23,7 +23,7 @@ version.workspace = true
 [dependencies]
 anyhow = "1.0.71"
 authenticode = { path = "../authenticode", version = "0.4.0", features = ["object", "std"] }
-clap = { version = "4.4.7", features = ["derive"] }
+clap.workspace = true
 cms = { version = "0.2.0", default-features = false }
 der = { version = "0.7.0", default-features = false, features = ["std"] }
 digest = { version = "0.10.0", default-features = false }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,6 +8,6 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-clap = { version = "4.4.7", default-features = false, features = ["derive", "std", "help"] }
+clap.workspace = true
 fs-err = "2.9.0"
 tempfile = "3.8.1"


### PR DESCRIPTION
This deduplicates the clap dep in authenticode-tool and xtask. Note that more features are now enabled in the xtask version (since "default-features=false" isn't set), but it doesn't really matter since it's an internal tool, and the extra features were probably enabled anyway due to feature unification.