### PR TITLE
Bump MSRV to 1.85

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - run: rustup toolchain install 1.81 --profile minimal --no-self-update
-      - run: rustup default 1.81
+      - run: rustup toolchain install 1.85 --profile minimal --no-self-update
+      - run: rustup default 1.85
       - uses: Swatinem/rust-cache@v2
       - run: rustc --version
       - run: cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/google/authenticode-rs"
-rust-version = "1.81"
+rust-version = "1.85"
 version = "0.4.3"
 
 [workspace.dependencies]


### PR DESCRIPTION
An indirect dependency now requires 1.85, so bump the authenticode MSRV
to match.
