### PR TITLE
Replace doc_auto_cfg with doc_cfg

### DIFF
--- a/authenticode/src/lib.rs
+++ b/authenticode/src/lib.rs
@@ -25,7 +25,7 @@
 //! [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
 #![forbid(unsafe_code)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // Allow using `std` if the `std` feature is enabled, or when running
 // tests. Otherwise enable `no_std`.
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]


### PR DESCRIPTION
The `doc_auto_cfg` feature has been subsumed by `doc_cfg`: https://github.com/rust-lang/rust/pull/138907