### PR TITLE
Validate messageDigest attribute matches raw econtent hash

### DIFF
--- a/authenticode/Cargo.toml
+++ b/authenticode/Cargo.toml
@@ -29,13 +29,14 @@ const-oid = { version = "0.9.0", default-features = false }
 der = { workspace = true, features = ["derive"] }
 digest.workspace = true
 object = { workspace = true, optional = true }
+sha1.workspace = true
+sha2.workspace = true
 spki = { version = "0.7.0", default-features = false }
 x509-cert = { version = "0.2.0", default-features = false }
 
 [dev-dependencies]
-sha1.workspace = true
-sha2.workspace = true
 
 [features]
 object = ["dep:object"]
 std = []
+

--- a/authenticode/src/signature.rs
+++ b/authenticode/src/signature.rs
@@ -97,6 +97,9 @@ pub enum AuthenticodeSignatureParseError {
 
     /// The `messageDigest` authenticated attribute is missing.
     MissingMessageDigestAuthenticatedAttribute,
+
+    /// The messageDigest authenticated attribute value does not match the hash of the encapsulated content.
+    MessageDigestMismatch,
 }
 
 impl Display for AuthenticodeSignatureParseError {
@@ -200,12 +203,39 @@ impl AuthenticodeSignature {
         }
 
         if let Some(signed_attrs) = &signer_info.signed_attrs {
-            // If we have signed_attrs, we _must_ have message-digest.
-            if !signed_attrs
+            let attr_digest = signed_attrs
                 .iter()
-                .any(|a| a.oid == const_oid::db::rfc6268::ID_MESSAGE_DIGEST)
-            {
-                return Err(AuthenticodeSignatureParseError::MissingMessageDigestAuthenticatedAttribute);
+                .find(|a| a.oid == const_oid::db::rfc6268::ID_MESSAGE_DIGEST)
+                .ok_or(AuthenticodeSignatureParseError::MissingMessageDigestAuthenticatedAttribute)?;
+
+            let embedded_any_val = attr_digest.values.get(0).ok_or(AuthenticodeSignatureParseError::MissingMessageDigestAuthenticatedAttribute)?;
+            let embedded_digest = embedded_any_val.decode_as::<der::asn1::OctetString>().map_err(AuthenticodeSignatureParseError::InvalidContentInfo)?;
+
+            let raw_econtent = signed_data
+                .encap_content_info
+                .econtent
+                .as_ref()
+                .ok_or(AuthenticodeSignatureParseError::EmptyEncapsulatedContent)?
+                .value();
+
+            let matches_hash = match signer_info.digest_alg.oid {
+                const_oid::db::rfc3279::ID_SHA1 => {
+                    use digest::Digest;
+                    let mut hasher = sha1::Sha1::new();
+                    hasher.update(raw_econtent);
+                    hasher.finalize().as_slice() == embedded_digest.as_bytes()
+                }
+                const_oid::db::rfc3560::ID_SHA256 => {
+                    use digest::Digest;
+                    let mut hasher = sha2::Sha256::new();
+                    hasher.update(raw_econtent);
+                    hasher.finalize().as_slice() == embedded_digest.as_bytes()
+                }
+                _ => false,
+            };
+
+            if !matches_hash {
+                return Err(AuthenticodeSignatureParseError::MessageDigestMismatch);
             }
         }
 

--- a/authenticode/tests/test_authenticode.rs
+++ b/authenticode/tests/test_authenticode.rs
@@ -277,3 +277,41 @@ fn test_cert_size_too_big() {
     );
     assert!(iter.next().is_none());
 }
+
+/// Test that a signature with a mismatching messageDigest authenticated attribute is rejected.
+#[test]
+fn test_message_digest_mismatch() {
+    let data = include_bytes!("testdata/tiny64.signed.efi");
+    let pe = PeFile64::parse(data.as_slice()).unwrap();
+    let attr_cert = AttributeCertificateIterator::new(&pe)
+        .unwrap()
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+
+    let sig = attr_cert.get_authenticode_signature().unwrap();
+    let encap = sig.encapsulated_content().unwrap();
+
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(encap);
+    let hash = hasher.finalize();
+
+    // Find the hash in the certificate data and corrupt it.
+    let mut mutated_data = attr_cert.data.to_vec();
+    let mut found = false;
+    for i in 0..=mutated_data.len().saturating_sub(hash.len()) {
+        if &mutated_data[i..i + hash.len()] == hash.as_slice() {
+            mutated_data[i] ^= 1;
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "Could not find the econtent hash in the signature data");
+
+    // Re-parse and verify it fails with MessageDigestMismatch.
+    let parse_err = authenticode::AuthenticodeSignature::from_bytes(&mutated_data).unwrap_err();
+    assert_eq!(parse_err, authenticode::AuthenticodeSignatureParseError::MessageDigestMismatch);
+}
+

--- a/authenticode/tests/test_errors.rs
+++ b/authenticode/tests/test_errors.rs
@@ -101,6 +101,7 @@ fn test_authenticode_signature_parse_error() {
     );
     format!("{}", AuthenticodeSignatureParseError::MissingContentTypeAuthenticatedAttribute);
     format!("{}", AuthenticodeSignatureParseError::MissingMessageDigestAuthenticatedAttribute);
+    format!("{}", AuthenticodeSignatureParseError::MessageDigestMismatch);
 }
 
 #[test]


### PR DESCRIPTION
This PR resolves the issue where the `authenticode` crate parsed signatures without verifying that the `messageDigest` authenticated attribute value matches the actual hash of the encapsulated content (`econtent`).

### Changes
- Updated `authenticode/Cargo.toml` to move `sha1` and `sha2` to `dependencies` (with `default-features = false`).
- Added the `MessageDigestMismatch` error variant to `AuthenticodeSignatureParseError`.
- Added the validation sequence in `AuthenticodeSignature::from_bytes` using `const_oid::db::rfc3279::ID_SHA1` and `const_oid::db::rfc3560::ID_SHA256` to hash `raw_econtent` and compare it against the embedded `messageDigest` octet string.
- Added error formatting tests in `test_errors.rs`.
- Added a regression test `test_message_digest_mismatch` in `test_authenticode.rs` that mutates the embedded digest and asserts that the parser returns `MessageDigestMismatch`.

Closes #261
