### PR TITLE
Drop `std` feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,13 +52,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test -p authenticode
 
-  test-authenticode-std:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo test -p authenticode -F std
-
   test-authenticode-tool:
     runs-on: ubuntu-latest
     steps:

--- a/authenticode-tool/Cargo.toml
+++ b/authenticode-tool/Cargo.toml
@@ -22,7 +22,7 @@ version.workspace = true
 
 [dependencies]
 anyhow = "1.0.71"
-authenticode = { path = "../authenticode", version = "0.6.0", features = ["object", "std"] }
+authenticode = { path = "../authenticode", version = "0.6.0", features = ["object"] }
 base16ct.workspace = true
 clap.workspace = true
 cms.workspace = true

--- a/authenticode/Cargo.toml
+++ b/authenticode/Cargo.toml
@@ -39,4 +39,3 @@ sha2.workspace = true
 
 [features]
 object = ["dep:object"]
-std = []

--- a/authenticode/src/lib.rs
+++ b/authenticode/src/lib.rs
@@ -17,18 +17,14 @@
 //!
 //! * `object`: Enables a dependency on [`object`] and impls [`PeTrait`]
 //!   for [`PeFile`].
-//! * `std`: Turns off `no_std` and impls [`std::error::Error`] for the
-//!   error types.
 //!
 //! [`PeFile`]: https://docs.rs/object/latest/object/read/pe/struct.PeFile.html
 //! [`object`]: https://docs.rs/object/latest/object/
-//! [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Allow using `std` if the `std` feature is enabled, or when running
-// tests. Otherwise enable `no_std`.
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// Allow using `std` only when running tests.
+#![cfg_attr(not(test), no_std)]
 #![warn(clippy::arithmetic_side_effects)]
 #![warn(missing_docs)]
 

--- a/authenticode/src/pe.rs
+++ b/authenticode/src/pe.rs
@@ -22,8 +22,7 @@ impl Display for PeOffsetError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PeOffsetError {}
+impl core::error::Error for PeOffsetError {}
 
 /// Various offsets within the PE file needed for authenticode hashing.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/authenticode/src/signature.rs
+++ b/authenticode/src/signature.rs
@@ -106,8 +106,7 @@ impl Display for AuthenticodeSignatureParseError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AuthenticodeSignatureParseError {}
+impl core::error::Error for AuthenticodeSignatureParseError {}
 
 /// Parsed authenticode signature.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/authenticode/src/win_cert.rs
+++ b/authenticode/src/win_cert.rs
@@ -74,8 +74,7 @@ impl Display for AttributeCertificateError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AttributeCertificateError {}
+impl core::error::Error for AttributeCertificateError {}
 
 /// Error returned by [`AttributeCertificate::get_authenticode_signature`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -106,8 +105,7 @@ impl Display for AttributeCertificateAuthenticodeError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AttributeCertificateAuthenticodeError {}
+impl core::error::Error for AttributeCertificateAuthenticodeError {}
 
 /// Raw data for a PE attribute certificate.
 ///


### PR DESCRIPTION
This was only used for implementing the `Error` trait on error types. Since `Error` is in `core` as of 1.81, this can be done unconditionally now.